### PR TITLE
Add getters and constructors for RistrettoPoint and EdwardsPoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,10 +3,9 @@ members = [
     "curve25519-dalek",
     "curve25519-dalek-derive",
     "ed25519-dalek",
-    "x25519-dalek"
+    "x25519-dalek",
 ]
 resolver = "2"
 
 [profile.dev]
 opt-level = 2
-

--- a/curve25519-dalek/Cargo.toml
+++ b/curve25519-dalek/Cargo.toml
@@ -1,14 +1,16 @@
 [package]
-name = "curve25519-dalek"
+name = "curve25519-dalek-arcium-fork"
 # Before incrementing:
 # - update CHANGELOG
 # - update README if required by semver
 # - if README was updated, also update module documentation in src/lib.rs
-version = "4.1.3"
+version = "4.1.4"
 edition = "2021"
 rust-version = "1.60.0"
-authors = ["Isis Lovecruft <isis@patternsinthevoid.net>",
-           "Henry de Valence <hdevalence@hdevalence.ca>"]
+authors = [
+    "Isis Lovecruft <isis@patternsinthevoid.net>",
+    "Henry de Valence <hdevalence@hdevalence.ca>",
+]
 readme = "README.md"
 license = "BSD-3-Clause"
 repository = "https://github.com/dalek-cryptography/curve25519-dalek/tree/main/curve25519-dalek"
@@ -17,17 +19,22 @@ documentation = "https://docs.rs/curve25519-dalek"
 categories = ["cryptography", "no-std"]
 keywords = ["cryptography", "crypto", "ristretto", "curve25519", "ristretto255"]
 description = "A pure-Rust implementation of group operations on ristretto255 and Curve25519"
-exclude = [
-    "**/.gitignore",
-    ".gitignore",
-]
+exclude = ["**/.gitignore", ".gitignore"]
 
 [package.metadata.docs.rs]
 rustdoc-args = [
-    "--html-in-header", "docs/assets/rustdoc-include-katex-header.html",
-    "--cfg", "docsrs",
+    "--html-in-header",
+    "docs/assets/rustdoc-include-katex-header.html",
+    "--cfg",
+    "docsrs",
 ]
-features = ["serde", "rand_core", "digest", "legacy_compatibility", "group-bits"]
+features = [
+    "serde",
+    "rand_core",
+    "digest",
+    "legacy_compatibility",
+    "group-bits",
+]
 
 [dev-dependencies]
 sha2 = { version = "0.10", default-features = false }
@@ -35,7 +42,9 @@ bincode = "1"
 criterion = { version = "0.5", features = ["html_reports"] }
 hex = "0.4.2"
 rand = "0.8"
-rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
+rand_core = { version = "0.6", default-features = false, features = [
+    "getrandom",
+] }
 
 [build-dependencies]
 rustc_version = "0.4.0"
@@ -51,10 +60,17 @@ ff = { version = "0.13", default-features = false }
 group = { version = "0.13", default-features = false, optional = true }
 rand_core = { version = "0.6.4", default-features = false, optional = true }
 digest = { version = "0.10", default-features = false, optional = true }
-subtle = { version = "2.6.0", default-features = false, features = ["const-generics"]}
-serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
+subtle = { version = "2.6.0", default-features = false, features = [
+    "const-generics",
+] }
+serde = { version = "1.0", default-features = false, optional = true, features = [
+    "derive",
+] }
 zeroize = { version = "1", default-features = false, optional = true }
-elliptic-curve = { version = "=0.14.0-rc.1", features = ["serde", "arithmetic"] }
+elliptic-curve = { version = "=0.14.0-rc.1", features = [
+    "serde",
+    "arithmetic",
+] }
 block-buffer = "=0.11.0-rc.3"
 crypto-common = "=0.2.0-rc.1"
 sec1 = "=0.8.0-rc.3"

--- a/curve25519-dalek/src/edwards.rs
+++ b/curve25519-dalek/src/edwards.rs
@@ -375,6 +375,33 @@ pub struct EdwardsPoint {
     pub(crate) T: FieldElement,
 }
 
+impl EdwardsPoint {
+    /// Create a new EdwardsPoint. We don't verify that the coordinates represent a valid point on the curve.
+    pub fn new_unchecked(X: FieldElement, Y: FieldElement, Z: FieldElement, T: FieldElement) -> EdwardsPoint {
+        EdwardsPoint {X, Y, Z, T}
+    }
+
+    /// Return the X-coordinate.
+    pub fn X(&self) -> FieldElement {
+        self.X
+    }
+
+    /// Return the Y-coordinate.
+    pub fn Y(&self) -> FieldElement {
+        self.Y
+    }
+
+    /// Return the Z-coordinate.
+    pub fn Z(&self) -> FieldElement {
+        self.Z
+    }
+
+    /// Return the T-coordinate.
+    pub fn T(&self) -> FieldElement {
+        self.T
+    }
+}
+
 // ------------------------------------------------------------------------
 // Constructors
 // ------------------------------------------------------------------------

--- a/curve25519-dalek/src/encodable_curve.rs
+++ b/curve25519-dalek/src/encodable_curve.rs
@@ -37,6 +37,7 @@ use crate::EdwardsPoint;
 use crate::RistrettoPoint;
 use crate::Scalar;
 
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, PartialOrd, Ord)]
 /// Empty struct for the curve
 pub struct Dalek {}

--- a/curve25519-dalek/src/field.rs
+++ b/curve25519-dalek/src/field.rs
@@ -62,7 +62,7 @@ cfg_if! {
         ///
         /// The `FieldElement` type is an alias for one of the platform-specific
         /// implementations.
-        pub(crate) type FieldElement = backend::serial::u64::field::FieldElement51;
+        pub type FieldElement = backend::serial::u64::field::FieldElement51;
     } else {
         /// A `FieldElement` represents an element of the field
         /// \\( \mathbb Z / (2\^{255} - 19)\\).

--- a/curve25519-dalek/src/lib.rs
+++ b/curve25519-dalek/src/lib.rs
@@ -94,7 +94,7 @@ pub mod encodable_curve;
 //------------------------------------------------------------------------
 
 // Finite field arithmetic mod p = 2^255 - 19
-pub(crate) mod field;
+pub mod field;
 
 // Arithmetic backends (using u32, u64, etc) live here
 #[cfg(docsrs)]

--- a/curve25519-dalek/src/ristretto.rs
+++ b/curve25519-dalek/src/ristretto.rs
@@ -485,6 +485,15 @@ impl<'de> Deserialize<'de> for CompressedRistretto {
 pub struct RistrettoPoint(pub(crate) EdwardsPoint);
 
 impl RistrettoPoint {
+    /// Create a new RistrettoPoint. We don't verify that point is in [2]E.
+    pub fn new_unchecked(point: EdwardsPoint) -> RistrettoPoint {
+        RistrettoPoint(point)
+    }
+    /// Return a representative of the equivalence class.
+    pub fn inner(&self) -> EdwardsPoint {
+        self.0
+    }
+
     /// Compress this point using the Ristretto encoding.
     pub fn compress(&self) -> CompressedRistretto {
         let mut X = self.0.X;

--- a/ed25519-dalek/Cargo.toml
+++ b/ed25519-dalek/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 authors = [
     "isis lovecruft <isis@patternsinthevoid.net>",
     "Tony Arcieri <bascule@gmail.com>",
-    "Michael Rosenberg <michael@mrosenberg.pub>"
+    "Michael Rosenberg <michael@mrosenberg.pub>",
 ]
 readme = "README.md"
 license = "BSD-3-Clause"
@@ -15,18 +15,22 @@ documentation = "https://docs.rs/ed25519-dalek"
 keywords = ["cryptography", "ed25519", "curve25519", "signature", "ECC"]
 categories = ["cryptography", "no-std"]
 description = "Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust."
-exclude = [ ".gitignore", "TESTVECTORS", "VALIDATIONVECTORS", "res/*" ]
+exclude = [".gitignore", "TESTVECTORS", "VALIDATIONVECTORS", "res/*"]
 rust-version = "1.60"
 
 [package.metadata.docs.rs]
 rustdoc-args = [
-    "--html-in-header", "docs/assets/rustdoc-include-katex-header.html",
-    "--cfg", "docsrs",
+    "--html-in-header",
+    "docs/assets/rustdoc-include-katex-header.html",
+    "--cfg",
+    "docsrs",
 ]
 features = ["batch", "digest", "hazmat", "pem", "serde"]
 
 [dependencies]
-curve25519-dalek = { version = "4", path = "../curve25519-dalek", default-features = false, features = ["digest"] }
+curve25519-dalek = { package = "curve25519-dalek-arcium-fork", version = "4", path = "../curve25519-dalek", default-features = false, features = [
+    "digest",
+] }
 ed25519 = { version = ">=2.2, <2.3", default-features = false }
 signature = { version = ">=2.0, <2.3", optional = true, default-features = false }
 sha2 = { version = "0.10", default-features = false }
@@ -39,8 +43,13 @@ serde = { version = "1.0", default-features = false, optional = true }
 zeroize = { version = "1.5", default-features = false, optional = true }
 
 [dev-dependencies]
-curve25519-dalek = { version = "4", path = "../curve25519-dalek", default-features = false, features = ["digest", "rand_core"] }
-x25519-dalek = { version = "2", path = "../x25519-dalek", default-features = false, features = ["static_secrets"] }
+curve25519-dalek = { package = "curve25519-dalek-arcium-fork", version = "4", path = "../curve25519-dalek", default-features = false, features = [
+    "digest",
+    "rand_core",
+] }
+x25519-dalek = { version = "2", path = "../x25519-dalek", default-features = false, features = [
+    "static_secrets",
+] }
 blake2 = "0.10"
 sha3 = "0.10"
 hex = "0.4"
@@ -60,7 +69,12 @@ required-features = ["rand_core"]
 
 [features]
 default = ["fast", "std", "zeroize"]
-alloc = ["curve25519-dalek/alloc", "ed25519/alloc", "serde?/alloc", "zeroize/alloc"]
+alloc = [
+    "curve25519-dalek/alloc",
+    "ed25519/alloc",
+    "serde?/alloc",
+    "zeroize/alloc",
+]
 std = ["alloc", "ed25519/std", "serde?/std", "sha2/std"]
 
 asm = ["sha2/asm"]

--- a/x25519-dalek/Cargo.toml
+++ b/x25519-dalek/Cargo.toml
@@ -18,35 +18,45 @@ repository = "https://github.com/dalek-cryptography/curve25519-dalek/tree/main/x
 homepage = "https://github.com/dalek-cryptography/curve25519-dalek"
 documentation = "https://docs.rs/x25519-dalek"
 categories = ["cryptography", "no-std"]
-keywords = ["cryptography", "curve25519", "key-exchange", "x25519", "diffie-hellman"]
-description = "X25519 elliptic curve Diffie-Hellman key exchange in pure-Rust, using curve25519-dalek."
-exclude = [
-    ".gitignore",
-    ".travis.yml",
-    "CONTRIBUTING.md",
+keywords = [
+    "cryptography",
+    "curve25519",
+    "key-exchange",
+    "x25519",
+    "diffie-hellman",
 ]
+description = "X25519 elliptic curve Diffie-Hellman key exchange in pure-Rust, using curve25519-dalek."
+exclude = [".gitignore", ".travis.yml", "CONTRIBUTING.md"]
 rust-version = "1.60"
 
 [badges]
-travis-ci = { repository = "dalek-cryptography/x25519-dalek", branch = "master"}
+travis-ci = { repository = "dalek-cryptography/x25519-dalek", branch = "master" }
 
 [package.metadata.docs.rs]
 rustdoc-args = [
-    "--html-in-header", "docs/assets/rustdoc-include-katex-header.html",
-    "--cfg", "docsrs",
+    "--html-in-header",
+    "docs/assets/rustdoc-include-katex-header.html",
+    "--cfg",
+    "docsrs",
 ]
 features = ["getrandom", "reusable_secrets", "serde", "static_secrets"]
 
 [dependencies]
-curve25519-dalek = { version = "4", path = "../curve25519-dalek", default-features = false }
+curve25519-dalek = { package = "curve25519-dalek-arcium-fork", version = "4", path = "../curve25519-dalek", default-features = false }
 rand_core = { version = "0.6", default-features = false }
-serde = { version = "1", default-features = false, optional = true, features = ["derive"] }
-zeroize = { version = "1", default-features = false, optional = true, features = ["zeroize_derive"] }
+serde = { version = "1", default-features = false, optional = true, features = [
+    "derive",
+] }
+zeroize = { version = "1", default-features = false, optional = true, features = [
+    "zeroize_derive",
+] }
 
 [dev-dependencies]
 bincode = "1"
 criterion = "0.5"
-rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
+rand_core = { version = "0.6", default-features = false, features = [
+    "getrandom",
+] }
 
 [[bench]]
 name = "x25519"


### PR DESCRIPTION
- rename package to `curve25519-dalek-arcium-fork`
- bump version to 4.1.4 (to match the version on crates.io); 4.1.5 will come right after
- make `field` module public, as well as `FieldElement`
- add (unchecked) constructors for `RistrettoPoint` and `EdwardsPoint`
- add `inner()` for `RistrettoPoint` and coordinate getters for `EdwardsPoint`
- derive `Serialize` and `Deserialize` for `Dalek`