### PR TITLE
Make FieldElement::invert(&self) public

### DIFF
--- a/curve25519-dalek/src/field.rs
+++ b/curve25519-dalek/src/field.rs
@@ -203,7 +203,7 @@ impl FieldElement {
     /// This function returns zero on input zero.
     #[rustfmt::skip] // keep alignment of explanatory comments
     #[allow(clippy::let_and_return)]
-    pub(crate) fn invert(&self) -> FieldElement {
+    pub fn invert(&self) -> FieldElement {
         // The bits of p-2 = 2^255 -19 -2 are 11010111111...11.
         //
         //                                 nonzero bits of exponent


### PR DESCRIPTION
Needed for the curve to extended Edwards conversion.